### PR TITLE
Add bootstrap and custom navbar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "solidus", "~> 3.1"
 gem 'solidus_auth_devise'
 gem 'solidus_paypal_commerce_platform'
+
+gem 'bootstrap', '~> 5.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,10 @@ GEM
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
+    bootstrap (5.2.0)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 2.11.5, < 3)
+      sassc-rails (>= 2.0.0)
     builder (3.2.4)
     byebug (11.1.3)
     cancancan (3.4.0)
@@ -197,6 +201,7 @@ GEM
     paypalhttp (1.0.1)
     pg (1.4.1)
     polyglot (0.3.5)
+    popper_js (2.11.5)
     psych (4.0.4)
       stringio
     public_suffix (4.0.7)
@@ -399,6 +404,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
+  bootstrap (~> 5.2.0)
   byebug
   capybara (>= 3.26)
   jbuilder (~> 2.7)

--- a/app/assets/javascript/spree/frontend/all.coffee
+++ b/app/assets/javascript/spree/frontend/all.coffee
@@ -1,0 +1,3 @@
+#= require jquery
+#= require jquery_ujs
+#= require spree

--- a/app/assets/stylesheets/spree/frontend/all.sass
+++ b/app/assets/stylesheets/spree/frontend/all.sass
@@ -1,0 +1,1 @@
+@import "bootstrap"

--- a/app/helpers/spree/base_helper_decorator.rb
+++ b/app/helpers/spree/base_helper_decorator.rb
@@ -1,0 +1,5 @@
+module Spree::BaseHelper
+    def logo(image_path = Spree::Config[:logo], img_options: {})
+        link_to image_tag(image_path, img_options), spree.root_path
+    end
+end

--- a/app/views/spree/layouts/spree_application.html.erb
+++ b/app/views/spree/layouts/spree_application.html.erb
@@ -1,0 +1,36 @@
+<!doctype html>
+<!--[if lt IE 7 ]> <html class="ie ie6" lang="<%= I18n.locale %>"> <![endif]-->
+<!--[if IE 7 ]>    <html class="ie ie7" lang="<%= I18n.locale %>"> <![endif]-->
+<!--[if IE 8 ]>    <html class="ie ie8" lang="<%= I18n.locale %>"> <![endif]-->
+<!--[if IE 9 ]>    <html class="ie ie9" lang="<%= I18n.locale %>"> <![endif]-->
+<!--[if gt IE 9]><!--><html lang="<%= I18n.locale %>"><!--<![endif]-->
+  <head data-hook="inside_head">
+    <%= render partial: 'spree/shared/head' %>
+  </head>
+  <body class="<%= body_class %> " id="<%= @body_id || 'default' %>" data-hook="body">
+
+    <div class="container-fluid">
+
+      <%= render partial: 'spree/shared/header' %>
+
+      <div id="wrapper" class="row" data-hook>
+
+        <%= taxon_breadcrumbs(@taxon) %>
+
+        <%= render partial: 'spree/shared/sidebar' if content_for? :sidebar %>
+
+        <div id="content" class="columns <%= !content_for?(:sidebar) ? "sixteen" : "twelve omega" %>" data-hook>
+          <%= flash_messages %>
+          <%= yield %>
+        </div>
+
+        <%= yield :templates %>
+
+      </div>
+
+      <%= render partial: 'spree/shared/footer' %>
+
+    </div>
+
+  </body>
+</html>

--- a/app/views/spree/shared/_header.html.erb
+++ b/app/views/spree/shared/_header.html.erb
@@ -1,0 +1,44 @@
+<!--  <header id="header" class="row" data-hook>
+  <figure id="logo" class="columns six" data-hook><%= logo %></figure>
+  <%= render partial: 'spree/shared/nav_bar' %>
+  <%= render partial: 'spree/shared/main_nav_bar' if store_menu? %>
+</header>
+-->
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">
+        <figure id="logo" class="columns six m-2" data-hook><%= logo img_options: { class: 'img-responsive my-auto mx-2', width: '138'} %></figure>
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="#">Home</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#">Link</a>
+        </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            Dropdown
+          </a>
+          <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <li><a class="dropdown-item" href="#">Action</a></li>
+            <li><a class="dropdown-item" href="#">Another action</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="dropdown-item" href="#">Something else here</a></li>
+          </ul>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link disabled">Disabled</a>
+        </li>
+      </ul>
+      <form class="d-flex">
+        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
+        <button class="btn btn-outline-success" type="submit">Search</button>
+      </form>
+    </div>
+  </div>
+</nav>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,7 @@ module SolidusFundamentalsCarlosse
     end
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    config.autoloader = :classic
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Quick Info
---
Added bootstrap 5 to the project, customization of the header with a bootstrap navbar

Migrations? :-1:

What does this change?
----
Includes bootstrap 5 with a gem
Adds a bootstrap navbar

How do you manually test this?
----
Execute rails server then browse to the solidus main page, the page now has a bootstrap navbar on top

Screenshots
----

### Desktop
![Screenshot 2022-07-22 at 17-11-33 Sample Store](https://user-images.githubusercontent.com/44456304/180575460-7ecf4508-ece8-42af-bd7d-af8e4251317b.png)

