### PR TITLE
Add style to product details page

### DIFF
--- a/app/controllers/spree/store_controller_decorator.rb
+++ b/app/controllers/spree/store_controller_decorator.rb
@@ -1,0 +1,7 @@
+class Spree::StoreController
+    before_action :load_taxonomies
+
+    def load_taxonomies
+        @taxonomies = Spree::Taxonomy.includes(root: :children)
+    end
+end

--- a/app/views/spree/products/_cart_form.html.erb
+++ b/app/views/spree/products/_cart_form.html.erb
@@ -1,0 +1,82 @@
+<%= form_for :order, url: populate_orders_path do |f| %>
+<div id="inside-product-cart-form" data-hook="inside_product_cart_form" itemprop="offers" itemscope
+    itemtype="http://schema.org/Offer">
+
+    <% if @product.price_for_options(current_pricing_options) and !@product.price.nil? %>
+    <div data-hook="product_price" class="columns five <%= !@product.has_variants? ? 'alpha' : 'omega' %>">
+
+        <div id="product-price">
+            <h6 class="visually-hidden"><%= t('spree.price') %></h6>
+            <div class="my-3">
+                <span class="display-6 py-3" itemprop="price"
+                    content="<%= @product.price_for_options(current_pricing_options).amount %>">
+                    <%= display_price(@product) %>
+                </span>
+                <span itemprop="priceCurrency" content="<%= current_pricing_options.currency %>"></span>
+            </div>
+
+            <% if @product.master.can_supply? %>
+            <link itemprop="availability" href="http://schema.org/InStock" />
+            <% elsif @product.variants.empty? %>
+            <br />
+            <span class="out-of-stock"><%= t('spree.out_of_stock') %></span>
+            <% end %>
+        </div>
+
+        <div class="accordion accordion-flush mt-5 mb-3" id="accordionFlushExample">
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="flush-headingOne">
+                    <button class="accordion-button collapsed bg-white" type="button" data-bs-toggle="collapse"
+                        data-bs-target="#flush-collapseOne" aria-expanded="false" aria-controls="flush-collapseOne">
+                        Details
+                    </button>
+                </h2>
+                <div id="flush-collapseOne" class="accordion-collapse collapse mt-4" aria-labelledby="flush-headingOne"
+                    data-bs-parent="#accordionFlushExample">
+                    <div data-hook="product_properties">
+                        <%= render partial: 'properties' %>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <% if @product.variants_and_option_values_for(current_pricing_options).any? %>
+        <div id="product-variants" class="mb-2">
+            <div class="form-floating">
+                <select class="form-select" name="variant_id" id="floatingVariant">
+                    <% @product.variants_and_option_values_for(current_pricing_options).each_with_index do |variant, index| %>
+                    <option value="<%= index %>">
+                        <%= variant_options variant %>
+                        <% if variant_price variant %>
+                        <span class="price diff"><%= variant_price variant %></span>
+                        <% end %>
+
+                        <% unless variant.can_supply? %>
+                        <span class="out-of-stock"><%= t('spree.out_of_stock') %></span>
+                        <% end %>
+                    </option>
+                    <% end %>
+                </select>
+                <label for="floatingVariant"><%= t('spree.variants') %></label>
+            </div>
+        </div>
+        <% else %>
+        <%= hidden_field_tag "variant_id", @product.master.id %>
+        <% end %>
+
+        <div class="input-group">
+            <%= number_field_tag :quantity, 1, class: 'form-control', min: 1 %>
+            <%= button_tag class: 'btn btn-dark', id: 'add-to-cart-button', type: :submit do %>
+            <%= t('spree.add_to_cart') %>
+            <% end %>
+        </div>
+    </div>
+    <% else %>
+    <div id="product-price">
+        <br>
+        <div><span class="price selling"
+                itemprop="price"><%= t('spree.product_not_available_in_this_currency') %></span></div>
+    </div>
+    <% end %>
+</div>
+<% end %>

--- a/app/views/spree/products/_image.html.erb
+++ b/app/views/spree/products/_image.html.erb
@@ -1,0 +1,9 @@
+<% if defined?(image) && image %>
+  <%= render 'spree/shared/image', image: image, size: :mini, itemprop: "image", options: { class: 'img-fluid' } %>
+<% else %>
+  <%= render 'spree/shared/image',
+    image: @product.gallery.images.first,
+    size: :product,
+    itemprop: "image",
+    options: { class: 'img-fluid' } %>
+<% end %>

--- a/app/views/spree/products/_properties.html.erb
+++ b/app/views/spree/products/_properties.html.erb
@@ -1,0 +1,11 @@
+<% unless @product_properties.empty? %>
+  <h6 class="fw-bold text-center"><%= t('spree.properties')%></h6>
+  <ul id="product-properties" class="list-group list-group-flush" data-hook>
+      <% @product_properties.each do |product_property| %>
+        <li class="list-group-item">
+          <strong><%= product_property.property.presentation %>: </strong><%= product_property.value %>
+        </li>
+      <% end %>
+      <% reset_cycle('properties') %>
+  </ul>
+<% end %>

--- a/app/views/spree/products/_taxons.html.erb
+++ b/app/views/spree/products/_taxons.html.erb
@@ -1,0 +1,14 @@
+<% if !@product.taxons.blank? %>
+  <div id="taxon-crumbs" data-hook class="alpha columns five omega">
+    <small class="text-muted my-2 fw-bold"><%= t('spree.look_for_similar_items') %></small>
+
+    <div data-hook="product_taxons">
+      <ul id="similar_items_by_taxon" data-hook>
+      <% @product.taxons.each do |taxon| %>
+        <li class="badge text-bg-dark p-2"><%= link_to taxon.name, seo_url(taxon), class: 'text-white text-decoration-none' %></li>
+      <% end %>
+      </ul>
+    </div>
+
+  </div>
+<% end %>

--- a/app/views/spree/products/show.html.erb
+++ b/app/views/spree/products/show.html.erb
@@ -1,0 +1,48 @@
+<% cache [I18n.locale, current_pricing_options, @product] do %>
+  <div class="row py-5" data-hook="product_show" itemscope itemtype="http://schema.org/Product">
+    <% @body_id = 'product-details' %>
+
+    <div class="col col-md-6" data-hook="product_left_part">
+      <div class="row" data-hook="product_left_part_wrap">
+
+        <div id="product-images" data-hook="product_images">
+          <div id="main-image" data-hook>
+            <%= render partial: 'image' %>
+          </div>
+          <!-- <div id="thumbnails" data-hook>
+            <%= render partial: 'thumbnails' %>
+          </div>
+          -->
+        </div>
+
+        <div data-hook="promotions">
+          <%= render partial: 'promotions' %>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="col col-md-6" data-hook="product_right_part">
+      <div class="row" data-hook="product_right_part_wrap">
+
+        <div id="product-description" data-hook="product_description">
+
+          <h1 class="product-title" itemprop="name"><%= @product.name %></h1>
+
+
+          <div itemprop="description" data-hook="description">
+            <%= product_description(@product) rescue t('spree.product_has_no_description') %>
+          </div>
+
+         <div id="cart-form" data-hook="cart_form">
+            <%= render partial: 'cart_form' %>
+          </div>
+
+        </div>
+
+        <%= render partial: 'taxons' %>
+
+      </div>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
Quick Info
---
Fixes bug when rendering product show view and adds a theme to product show view

Migrations? :-1:

How did you accomplish this change?
----
- Loading taxonomies in all controllers
- Overwriting products views

How do you manually test this?
----
Execute rails server then browse to the solidus main page, select a product the show view now should work and has to be styled

Screenshots
----

### Desktop
![Screenshot 2022-07-22 at 17-44-15 Solidus Long Sleeve - Sample Store](https://user-images.githubusercontent.com/44456304/180577884-142f8366-d9e1-480c-bff6-197d63d73dd7.png)
![Screenshot 2022-07-22 at 17-44-23 Solidus Mug - Sample Store](https://user-images.githubusercontent.com/44456304/180577888-f6c0d0bc-5e60-40d3-affb-1c0488dccc46.png)



