### PR TITLE
Add logic to render header in app or devise views

### DIFF
--- a/app/helpers/spree/base_helper_decorator.rb
+++ b/app/helpers/spree/base_helper_decorator.rb
@@ -1,19 +1,27 @@
 module Spree::BaseHelper
-    def logo(image_path = Spree::Config[:logo], img_options: {})
-        link_to image_tag(image_path, img_options), spree.root_path
+  def layout_partial
+    if devise_controller?
+      'spree/base/devise'
+    else
+      'spree/base/application'
     end
+  end
 
-    def nav_tree(root_taxon, current_taxon, max_level = 1)
-        return '' if max_level < 1 || root_taxon.children.empty?
-        content_tag :ul, class: 'dropdown-menu' do
-          taxons = root_taxon.children.map do |taxon|
-            css_class = (current_taxon && current_taxon.self_and_ancestors.include?(taxon)) ? 'active' : nil
-            content_tag :li, class: css_class do
-             link_to(taxon.name, seo_url(taxon), class: 'dropdown-item') +
-               taxons_tree(taxon, current_taxon, max_level - 1)
-            end
+  def logo(image_path = Spree::Config[:logo], img_options: {})
+      link_to image_tag(image_path, img_options), spree.root_path
+  end
+
+  def nav_tree(root_taxon, current_taxon, max_level = 1)
+      return '' if max_level < 1 || root_taxon.children.empty?
+      content_tag :ul, class: 'dropdown-menu' do
+        taxons = root_taxon.children.map do |taxon|
+          css_class = (current_taxon && current_taxon.self_and_ancestors.include?(taxon)) ? 'active' : nil
+          content_tag :li, class: css_class do
+           link_to(taxon.name, seo_url(taxon), class: 'dropdown-item') +
+             taxons_tree(taxon, current_taxon, max_level - 1)
           end
-          safe_join(taxons, "\n")
         end
-    end
+        safe_join(taxons, "\n")
+      end
+  end
 end

--- a/app/views/spree/base/_application.html.erb
+++ b/app/views/spree/base/_application.html.erb
@@ -1,0 +1,19 @@
+<%= render partial: 'spree/shared/header' %>
+
+<div class="container">
+    <div id="wrapper" class="row" data-hook>
+
+        <%= render partial: 'spree/shared/sidebar' if content_for? :sidebar %>
+
+        <div id="content" class="columns <%= !content_for?(:sidebar) ? "sixteen" : "twelve omega" %>" data-hook>
+            <%= flash_messages %>
+            <%= yield %>
+        </div>
+
+        <%= yield :templates %>
+
+    </div>
+
+    <%= render partial: 'spree/shared/footer' %>
+
+</div>

--- a/app/views/spree/base/_devise.html.erb
+++ b/app/views/spree/base/_devise.html.erb
@@ -1,0 +1,14 @@
+<div class="container">
+    <div id="wrapper" class="row" data-hook>
+
+        <%= render partial: 'spree/shared/sidebar' if content_for? :sidebar %>
+
+        <div id="content" class="columns <%= !content_for?(:sidebar) ? "sixteen" : "twelve omega" %>" data-hook>
+            <%= flash_messages %>
+            <%= yield %>
+        </div>
+
+        <%= yield :templates %>
+
+    </div>
+</div>

--- a/app/views/spree/layouts/spree_application.html.erb
+++ b/app/views/spree/layouts/spree_application.html.erb
@@ -9,27 +9,7 @@
   </head>
   <body class="<%= body_class %> " id="<%= @body_id || 'default' %>" data-hook="body">
 
-    <%= render partial: 'spree/shared/header' %>
-
-    <div class="container">
-      <div id="wrapper" class="row" data-hook>
-
-        <%= taxon_breadcrumbs(@taxon) %>
-
-        <%= render partial: 'spree/shared/sidebar' if content_for? :sidebar %>
-
-        <div id="content" class="columns <%= !content_for?(:sidebar) ? "sixteen" : "twelve omega" %>" data-hook>
-          <%= flash_messages %>
-          <%= yield %>
-        </div>
-
-        <%= yield :templates %>
-
-      </div>
-
-      <%= render partial: 'spree/shared/footer' %>
-
-    </div>
+    <%= render layout_partial %>
 
   </body>
 </html>


### PR DESCRIPTION
Quick Info
---
Creates a layout logic to render specific elements in login or app

Migrations? :-1:

What does this change?
----
Creates two different layouts for devise/authentication use or general app use

Why are you changing that?
----
This fixes a bug when rendering authentication pages

How did you accomplish this change?
----
Created a new layout for devise removing header with this the taxonomies variable is not necessary in login, signup and reset password views

How do you manually test this?
----
Execute rails server then browse to the solidus main page, select products and add them to the cart, then check out the cart and click on login or register
