### PR TITLE
Add style to devise authentication pages

### DIFF
--- a/app/assets/stylesheets/spree/frontend/all.scss
+++ b/app/assets/stylesheets/spree/frontend/all.scss
@@ -1,2 +1,3 @@
 @import "bootstrap";
 @import "spree/frontend/products";
+@import "spree/frontend/checkout";

--- a/app/assets/stylesheets/spree/frontend/checkout.scss
+++ b/app/assets/stylesheets/spree/frontend/checkout.scss
@@ -1,0 +1,47 @@
+.form-container {
+    background-color: #FFFFFF;
+    display: block;
+    min-height: 100vh;
+    padding: 45px 55px 55px 55px;
+    width: 560px;
+}
+
+.image-container {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    min-height: 100vh;
+    width: 100%;
+}
+
+.img-container {
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
+    position: relative;
+    width: calc(100% - 560px);
+    z-index: 1;
+
+    &:before {
+        content: "";
+        background: rgba(0, 0, 0, 0.1);
+        display: block;
+        height: 100%;
+        left: 0;
+        position: absolute;
+        top: 0;
+        width: 100%;
+        z-index: -1;
+    }
+}
+
+.wrap-image {
+    align-items: stretch;
+    background: #FFFFFF;
+    display: flex;
+    flex-direction: row-reverse;
+    flex-wrap: wrap;
+    overflow: hidden;
+    width: 100%;
+}

--- a/app/views/spree/base/_devise.html.erb
+++ b/app/views/spree/base/_devise.html.erb
@@ -1,5 +1,5 @@
-<div class="container">
-    <div id="wrapper" class="row" data-hook>
+<div class="container-fluid p-0">
+    <div id="wrapper" data-hook>
 
         <%= render partial: 'spree/shared/sidebar' if content_for? :sidebar %>
 

--- a/app/views/spree/checkout/registration.html.erb
+++ b/app/views/spree/checkout/registration.html.erb
@@ -1,0 +1,28 @@
+<div class="container">
+    <div class="row d-flex justify-content-center align-items-center vh-100">
+        <div class="col-12 col-md-4 d-flex justify-content-center">
+            <%= render partial: 'spree/user_sessions/login' %>
+        </div>
+        <div class="col-12 col-md-4">
+            <img src="https://mdbcdn.b-cdn.net/img/Photos/new-templates/bootstrap-registration/draw1.webp"
+                  class="img-fluid" alt="Sample image">
+        </div>
+        <div class="col-12 col-md-4 d-flex justify-content-center">
+        <% if Spree::Config[:allow_guest_checkout] %>
+            <div id="guest_checkout" data-hook class="columns omega eight">
+            <h5 class="lead text-center"><%= t('spree.guest_user_account') %></h5>
+            <% if flash[:registration_error] %>
+                <div class='flash error'><%= flash[:registration_error] %></div>
+            <% end %>
+            <%= form_for @order, url: update_checkout_registration_path, method: :put, html: { id: 'checkout_form_registration' } do |f| %>
+                <div class="form-floating">
+                    <%= f.email_field :email, class: 'form-control' %>
+                    <%= f.label :email, t('spree.email') %><br />
+                </div>
+                <div><%= f.submit t('spree.continue'), class: 'btn btn-dark btn-block w-100' %></div>
+            <% end %>
+            </div>
+        <% end %>
+        </div>
+    </div>
+</div>

--- a/app/views/spree/shared/_login.html.erb
+++ b/app/views/spree/shared/_login.html.erb
@@ -1,0 +1,18 @@
+<%= form_for Spree::User.new, as: :spree_user, url: spree.create_new_session_path do |f| %>
+  <div id="password-credentials">
+    <div class="form-floating">
+      <%= f.email_field :email, class: 'form-control', tabindex: 1, autofocus: true %>
+      <%= f.label :email, t('sdivree.email') %><br />
+    </div>
+    <div class="form-floating">
+      <%= f.password_field :password, class: 'form-control', tabindex: 2 %>
+      <%= f.label :password, t('spree.password') %><br />
+    </div>
+  </div>
+  <p>
+    <%= f.check_box :remember_me, tabindex: 3, class: "form-check-input" %>
+    <%= f.label :remember_me, t('spree.remember_me') %>
+  </p>
+
+  <p><%= f.submit t('spree.login'), class: 'btn btn-dark w-100', tabindex: 4 %></p>
+<% end %>

--- a/app/views/spree/shared/_user_form.html.erb
+++ b/app/views/spree/shared/_user_form.html.erb
@@ -1,0 +1,17 @@
+<div class="form-floating">
+  <%= f.email_field :email, class: 'form-control' %>
+  <%= f.label :email, t('spree.email') %><br />
+</div>
+<div id="password-credentials">
+  <div class="form-floating">
+    <%= f.password_field :password, class: 'form-control' %>
+    <%= f.label :password, t('spree.password') %><br />
+  </div>
+
+  <div class="form-floating">
+    <%= f.password_field :password_confirmation, class: 'form-control' %>
+    <%= f.label :password_confirmation, t('spree.confirm_password') %><br />
+  </div>
+</div>
+
+<div data-hook="signup_below_password_fields"></div>

--- a/app/views/spree/user_passwords/new.html.erb
+++ b/app/views/spree/user_passwords/new.html.erb
@@ -1,0 +1,26 @@
+<div class="container-fluid p-0 m-0">
+    <div class="image-container">
+        <div class="wrap-image">
+            <div class="form-container" id="forgot-password">
+                <figure id="logo" class="d-flex justify-content-center" data-hook>
+                    <%= logo img_options: { class: 'img-responsive my-auto mx-auto', width: '250'} %></figure>
+                <div data-hook="signup">
+                    <h5 class="lead text-center my-4"><%= t('spree.forgot_password') %></h5>
+                    <p><%= t('spree.instructions_to_reset_password') %></p>
+                    <%= form_for Spree::User.new, as: :spree_user, url: spree.reset_password_path do |f| %>
+                    <div class="form-floating">
+                        <%= f.email_field :email, required: true, class: 'form-control my-4' %>
+                        <%= f.label :email, t('spree.email') %>
+                    </div>
+                    <p>
+                        <%= f.submit t('spree.reset_password'), class: 'btn btn-dark w-100' %>
+                    </p>
+                    <% end %>
+                </div>
+            </div>
+            <div class="img-container overlay-gradient-bottom"
+                style="background-image: url('https://images.unsplash.com/photo-1599420186946-7b6fb4e297f0?ixlib=rb-1.2.1&ixid=MnwxMjA3fDF8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80');">
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/spree/user_registrations/new.html.erb
+++ b/app/views/spree/user_registrations/new.html.erb
@@ -1,0 +1,29 @@
+<% @body_id = 'signup' %>
+
+<div class="container-fluid p-0 m-0">
+  <div class="image-container">
+    <div class="wrap-image">
+      <div class="form-container">
+        <figure id="logo" class="d-flex justify-content-center" data-hook><%= logo img_options: { class: 'img-responsive my-auto mx-auto', width: '250'} %></figure>
+        <h4 class="py-4 text-dark text-center"><%= t('spree.new_customer') %></h4>
+        <%= render 'spree/shared/error_messages', target: resource %>
+
+        <div data-hook="signup">
+          <%= form_for resource, as: :spree_user, url: spree.registration_path(resource) do |f| %>
+          <div data-hook="signup_inside_form">
+            <%= render partial: 'spree/shared/user_form', locals: { f: f } %>
+            <p><%= f.submit t('spree.create'), class: 'btn btn-dark w-100' %></p>
+          </div>
+          <% end %>
+          <%= link_to t('spree.login_as_existing'), spree.login_path, class: 'text-dark' %>
+
+        </div>
+      </div>
+      <div class="img-container overlay-gradient-bottom"
+        style="background-image: url('https://images.unsplash.com/photo-1599420186946-7b6fb4e297f0?ixlib=rb-1.2.1&ixid=MnwxMjA3fDF8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80');">
+      </div>
+    </div>
+  </div>
+</div>
+
+<div data-hook="login_extras"></div>

--- a/app/views/spree/user_sessions/_login.html.erb
+++ b/app/views/spree/user_sessions/_login.html.erb
@@ -1,0 +1,13 @@
+<% if flash[:alert] %>
+  <div class="flash errors"><%= flash[:alert] %></div>
+<% end %>
+
+<% @body_id = 'login' %>
+<div id="existing-customer">
+  <h5 class="lead text-center"><%= t('spree.login_as_existing') %></h5>
+  <div data-hook="login">
+    <%= render partial: 'spree/shared/login' %>
+    <%= link_to t('spree.create_a_new_account'), spree.signup_path, class: 'text-dark' %> | <%= link_to t('spree.forgot_password'), spree.recover_password_path, class: 'text-dark' %>
+  </div>
+</div>
+<div data-hook="login_extras"></div>

--- a/app/views/spree/user_sessions/new.html.erb
+++ b/app/views/spree/user_sessions/new.html.erb
@@ -1,0 +1,24 @@
+<div class="container-fluid p-0 m-0">
+  <div class="image-container">
+    <div class="wrap-image">
+      <div class="form-container">
+        <figure id="logo" class="d-flex justify-content-center" data-hook><%= logo img_options: { class: 'img-responsive my-auto mx-auto', width: '250'} %></figure>
+        <div data-hook="signup">
+          <h5 class="lead text-center my-4"><%= t('spree.login_as_existing') %></h5>
+          <% if flash[:alert] %>
+            <div class="flash errors"><%= flash[:alert] %></div>
+          <% end %>
+          <div data-hook="login">
+            <%= render partial: 'spree/shared/login' %>
+            <%= link_to t('spree.create_a_new_account'), spree.signup_path, class: 'text-dark' %> | <%= link_to t('spree.forgot_password'), spree.recover_password_path, class: 'text-dark' %>
+          </div>
+        </div>
+      </div>
+      <div class="img-container overlay-gradient-bottom"
+        style="background-image: url('https://images.unsplash.com/photo-1599420186946-7b6fb4e297f0?ixlib=rb-1.2.1&ixid=MnwxMjA3fDF8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80');">
+      </div>
+    </div>
+  </div>
+</div>
+
+<div data-hook="login_extras"></div>


### PR DESCRIPTION
Quick Info
---
Customize frontend for authentication pages

Migrations? :-1:

How did you accomplish this change?
----
Overwriting solidus_auth_devise views to change styles of login, register, and forgot password

How do you manually test this?
----
Execute rails server then browse to the solidus main page, in the process of checkout select options for login or register

Screenshots
----

### Desktop
![Screenshot 2022-07-26 at 11-41-19 Login - Sample Store](https://user-images.githubusercontent.com/44456304/181064802-2bbca417-dce8-4c2d-8e73-354d97d971c2.png)
![Screenshot 2022-07-26 at 11-41-10 Sample Store](https://user-images.githubusercontent.com/44456304/181064817-35dd1035-18cd-4781-a051-1dc09227392c.png)
![Screenshot 2022-07-26 at 11-40-59 Sample Store](https://user-images.githubusercontent.com/44456304/181064843-fc4064f5-12c1-4ab3-acf3-c279a2d870ec.png)
![Screenshot 2022-07-26 at 11-41-27 Sample Store](https://user-images.githubusercontent.com/44456304/181064849-9f28c1ca-e7ae-4cd3-96be-dce5eb655d86.png)

