### PR TITLE
Add styles to checkout process

### DIFF
--- a/app/helpers/spree/checkout_helper_decorator.rb
+++ b/app/helpers/spree/checkout_helper_decorator.rb
@@ -1,0 +1,30 @@
+module Spree
+  module CheckoutHelper
+
+    def checkout_progress
+      states = checkout_states
+      items = states.map do |state|
+        text = I18n.t("spree.order_state.#{state}").titleize
+
+        css_classes = []
+        current_index = states.index(@order.state)
+        state_index = states.index(state)
+
+        if state_index < current_index
+          css_classes << 'completed'
+          text = link_to text, checkout_state_path(state)
+        end
+
+        css_classes << 'next' if state_index == current_index + 1
+        css_classes << 'current' if state == @order.state
+        css_classes << 'active' if state_index == current_index
+        css_classes << 'disabled' if state_index > current_index
+        css_classes << 'first' if state_index == 0
+        css_classes << 'last' if state_index == states.length - 1
+        # It'd be nice to have separate classes but combining them with a dash helps out for IE6 which only sees the last class
+        content_tag('li', content_tag('span', text), class: "nav-link mx-3 #{css_classes.join(' ')}")
+      end
+      content_tag('ol', raw(items.join("\n")), class: 'nav nav-pills nav-fill', id: "checkout-step-#{@order.state}")
+    end
+  end
+end

--- a/app/views/spree/address/_form.html.erb
+++ b/app/views/spree/address/_form.html.erb
@@ -1,0 +1,106 @@
+<% address_id = address_type.chars.first %>
+<div class="inner" data-hook=<%="#{address_type}_inner" %>>
+
+  <div class="form-floating" id="<%= "#{address_id}name" %>">
+    <%= form.text_field :name, class: 'form-control', autocomplete: address_type + ' name', required: true, autofocus: true %>
+    <%= form.label :name, t('spree.name') %>
+  </div>
+
+  <% if Spree::Config[:company] %>
+    <div class="form-floating" id=<%="#{address_id}company" %>>
+      <%= form.text_field :company, autocomplete: address_type + ' organization', class: 'form-control' %>
+      <%= form.label :company, t('spree.company') %>
+    </div>
+  <% end %>
+
+  <div class="row my-3">
+    <div class="col-12 col-md-6">
+      <div class="form-floating" id=<%="#{address_id}address1" %>>
+        <%= form.text_field :address1, class: 'form-control required', autocomplete: address_type + ' address-line1',  required: true %>
+        <%= form.label :address1, t('spree.street_address') %>
+      </div>
+    </div>
+    <div class="col-12 col-md-6">
+      <div class="form-floating mb-3" id=<%="#{address_id}address2" %>>
+        <%= form.text_field :address2, autocomplete: address_type + ' address-line2', class: 'form-control' %>
+        <%= form.label :address2, I18n.t('spree.street_address_2') %>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12 col-md-6">
+      <div class="form-floating" id=<%="#{address_id}city" %>>
+        <%= form.text_field :city, class: 'form-control required', autocomplete: address_type + ' address-level2',  required: true %>
+        <%= form.label :city, t('spree.city') %>
+      </div>
+    </div>
+    <div class="col-12 col-md-6">
+      <div class="form-floating mb-3" id=<%="#{address_id}country" %>>
+          <%= form.collection_select :country_id, available_countries, :id, :name, {},
+            class: 'required form-select',
+            autocomplete: address_type + ' country-name',
+            required: true
+          %>
+        <%= form.label :country_id, t('spree.country') %>
+      </div>
+    </div>
+  </div>
+
+  <% if Spree::Config[:address_requires_state] %>
+    <div class="field field-required mb-3" id=<%="#{address_id}state" %>>
+      <% have_states = !address.country.states.empty? %>
+      <%= form.label :state, t('spree.state') %>
+
+      <span class="js-address-fields" style="display: none;">
+        <%=
+          form.collection_select(
+            :state_id, address.country.states, :id, :name,
+            {include_blank: true},
+            {
+              class: have_states ? 'required form-control' : '',
+              style: have_states ? '' : 'display: none;',
+              disabled: !have_states,
+              autocomplete: address_type + ' address-level1',
+            })
+          %>
+        <%=
+          form.text_field(
+            :state_name,
+            class: !have_states ? 'required' : '',
+            style: have_states ? 'display: none;' : '',
+            disabled: have_states,
+            autocomplete: address_type + ' address-level1',
+          )
+        %>
+      </span>
+      <noscript>
+        <%= form.text_field :state_name, class: 'required', autocomplete: address_type + ' address-level1',  required: true %>
+      </noscript>
+    </div>
+  <% end %>
+
+
+   <div class="row my-3">
+    <div class="col-12 col-md-6">
+      <div class="field form-floating <%= 'field-required' if address.require_zipcode? %>" id=<%="#{address_id}zipcode" %>>
+        <%= form.text_field :zipcode, class: "#{'required form-control' if address.require_zipcode?}", autocomplete: address_type + ' postal-code',  required: true %>
+        <%= form.label :zipcode, t('spree.zip') %>
+      </div>
+    </div>
+    <div class="col-12 col-md-6">
+      <div class="field form-floating mb-3 <%= 'field-required' if address.require_phone? %>" id=<%="#{address_id}phone" %>>
+        <% phone_hash = address.require_phone? ? { class: 'required', required: true } : {} %>
+        <%= form.phone_field :phone, phone_hash.merge({ autocomplete: address_type + ' home tel', class: 'form-control' }) %>
+        <%= form.label :phone, t('spree.phone') %>
+      </div>
+    </div>
+  </div>
+
+  <% if Spree::Config[:alternative_shipping_phone] %>
+    <div class="field form-floating" id=<%="#{address_id}altphone" %>>
+      <%= form.phone_field :alternative_phone, autocomplete: address_type + ' tel', class: 'form-control' %>
+      <%= form.label :alternative_phone, t('spree.alternative_phone') %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spree/checkout/_address.html.erb
+++ b/app/views/spree/checkout/_address.html.erb
@@ -1,0 +1,33 @@
+<div class="columns alpha six" data-hook="billing_fieldset_wrapper">
+  <fieldset id="billing" data-hook>
+    <%= form.fields_for :bill_address do |bill_form| %>
+      <legend align="center"><%= t('spree.billing_address') %></legend>
+      <%= render partial: 'spree/address/form', locals: { form: bill_form, address_type: 'billing', address: @order.bill_address } %>
+    <% end %>
+  </fieldset>
+</div>
+
+<div class="columns omega six" data-hook="shipping_fieldset_wrapper">
+  <fieldset id="shipping" data-hook>
+    <%= form.fields_for :ship_address do |ship_form| %>
+      <legend align="center"><%= t('spree.shipping_address') %></legend>
+      <div class="checkbox" data-hook="use_billing">
+        <%= check_box_tag 'order[use_billing]', '1', @order.shipping_eq_billing_address? %>
+        <%= label_tag :order_use_billing, t('spree.use_billing_address'), id: 'use_billing' %>
+      </div>
+      <%= render partial: 'spree/address/form', locals: { form: ship_form, address_type: 'shipping', address: @order.ship_address } %>
+    <% end %>
+  </fieldset>
+</div>
+<hr class="clear" />
+
+<div class="form-buttons my-4" data-hook="buttons">
+  <%= submit_tag t('spree.save_and_continue'), class: 'continue btn btn-sm btn-dark' %>
+  <% if spree_current_user %>
+    <span data-hook="save_user_address">
+      &nbsp; &nbsp;
+      <%= check_box_tag 'save_user_address', '1', spree_current_user.respond_to?(:persist_order_address), class: 'form-check-input' %>
+      <%= label_tag :save_user_address, t('spree.save_my_address') %>
+    </span>
+  <% end %>
+</div>

--- a/app/views/spree/checkout/_confirm.html.erb
+++ b/app/views/spree/checkout/_confirm.html.erb
@@ -1,0 +1,25 @@
+<fieldset id="order_details" data-hook>
+  <div class="clear"></div>
+  <legend align="center"><%= t('spree.confirm') %></legend>
+  <%= render partial: 'spree/shared/order_details', locals: { order: @order } %>
+</fieldset>
+
+<br />
+
+<div class="form-buttons" data-hook="buttons">
+  <% Spree::Frontend::Config[:require_terms_and_conditions_acceptance].tap do |requires_acceptance| %>
+    <% if requires_acceptance %>
+      <div class="terms_and_conditions" data-hook="terms_and_conditions">
+        <div class="policy"><%= render partial: "spree/checkout/terms_and_conditions" %></div>
+        <%= check_box_tag :accept_terms_and_conditions, 'accepted', false %>
+        <%= label_tag :accept_terms_and_conditions, t('spree.agree_to_terms_of_service') %>
+      </div>
+    <% end %>
+
+    <%= submit_tag t('spree.place_order'),
+      disabled: requires_acceptance,
+      class: "continue btn btn-sm btn-dark my-3 #{ 'disabled' if requires_acceptance }" %>
+  <% end %>
+
+  <script>Spree.disableSaveOnClick();</script>
+</div>

--- a/app/views/spree/checkout/_coupon_code.html.erb
+++ b/app/views/spree/checkout/_coupon_code.html.erb
@@ -1,0 +1,12 @@
+<div class="coupon-code" data-hook='coupon_code'>
+  <%= form_for order, url: update_checkout_path(order.state) do |form| %>
+    <%= form.label :coupon_code %>
+    <%= form.text_field :coupon_code, placeholder: true, class: 'form-control' %>
+
+    <button type="submit" class="button coupon-code-apply-button btn btn-sm btn-success my-3" id="coupon-code-apply-button">
+      <%= t('spree.apply_code') %>
+    </button>
+  <% end %>
+
+  <div id='coupon_status'></div>
+</div>

--- a/app/views/spree/checkout/_delivery.html.erb
+++ b/app/views/spree/checkout/_delivery.html.erb
@@ -1,0 +1,108 @@
+<fieldset id='shipping_method' data-hook>
+  <legend align="center"><%= t('spree.delivery') %></legend>
+  <div class="inner" data-hook="shipping_method_inner">
+    <div id="methods">
+      <%= form.fields_for :shipments do |ship_form| %>
+
+        <div class="shipment">
+          <h3 class="stock-location lead" data-hook="stock-location">
+            <%= t('spree.package_from') %>
+            <strong class="stock-location-name" data-hook="stock-location-name"><%= ship_form.object.stock_location.name %></strong>
+          </h3>
+
+          <table class="stock-contents table table-striped" data-hook="stock-contents">
+            <colgroup>
+              <col style="width: 10%;" />
+              <col style="width: 60%;" />
+              <col style="width: 10%;" />
+              <col style="width: 20%;" />
+            </colgroup>
+            <thead>
+              <th></th>
+              <th align='left'><%= t('spree.item') %></th>
+              <th><%= t('spree.qty') %></th>
+              <th><%= t('spree.price') %></th>
+            </thead>
+            <tbody>
+              <% ship_form.object.manifest.each do |item| %>
+                <tr class="stock-item">
+                  <td class="item-image">
+                    <%= render 'spree/shared/image',
+                      image: (item.variant.gallery.images.first || item.variant.product.gallery.images.first),
+                      size: :mini %>
+                  </td>
+                  <td class="item-name"><%= item.variant.name %></td>
+                  <td class="item-qty"><%= item.quantity %></td>
+                  <td class="item-price"><%= display_price(item.variant) %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+
+          <h5 class="stock-shipping-method-title"><%= t('spree.shipping_method') %></h5>
+          <ul class="radios list-group list-group-flush">
+            <% ship_form.object.shipping_rates.each do |rate| %>
+              <li class="list-group-item">
+                <label>
+                  <%= ship_form.radio_button :selected_shipping_rate_id, rate.id %>
+                  <span class="rate-name"><%= rate.name %></span>
+                  <span class="rate-cost"><%= rate.display_cost %></span>
+                </label>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+
+      <% end %>
+
+      <% if @differentiator.try(:missing?) %>
+        <div class="shipment unshippable">
+          <h3 class="stock-location" data-hook="stock-location">
+            <%= t('spree.unshippable_items') %>
+          </h3>
+          <table class="stock-contents table table-striped" data-hook="stock-missing">
+            <colgroup>
+              <col style="width: 10%;" />
+              <col style="width: 60%;" />
+              <col style="width: 10%;" />
+              <col style="width: 20%;" />
+            </colgroup>
+            <thead>
+              <th></th>
+              <th align='left'><%= t('spree.item') %></th>
+              <th><%= t('spree.qty') %></th>
+              <th><%= t('spree.price') %></th>
+            </thead>
+            <tbody>
+              <% @differentiator.missing.each do |variant, quantity| %>
+                <tr class="stock-item">
+                  <td class="item-image">
+                    <%= render 'spree/shared/image',
+                      image: (variant.gallery.images.first || variant.product.gallery.images.first),
+                      size: :mini %>
+                  </td>
+                  <td class="item-name"><%= variant.name %></td>
+                  <td class="item-qty"><%= quantity %></td>
+                  <td class="item-price"><%= display_price(variant) %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
+
+    </div>
+    <% if Spree::Config[:shipping_instructions] %>
+      <p id="minstrs" data-hook>
+        <%= form.label :special_instructions, t('spree.shipping_instructions') %><br />
+        <%= form.text_area :special_instructions, cols: 40, rows: 7 %>
+      </p>
+    <% end %>
+  </div>
+</fieldset>
+
+<br />
+
+<div class="form-buttons" data-hook="buttons">
+  <%= submit_tag t('spree.save_and_continue'), class: 'continue btn btn-sm btn-dark my-4' %>
+</div>

--- a/app/views/spree/checkout/_payment.html.erb
+++ b/app/views/spree/checkout/_payment.html.erb
@@ -1,0 +1,67 @@
+<fieldset id="payment" data-hook>
+  <legend align="center"><%= t('spree.payment_information') %></legend>
+  <div data-hook="checkout_payment_step">
+    <% if @wallet_payment_sources.present? %>
+      <div class="card_options">
+        <%= radio_button_tag 'use_existing_card', 'yes', true %>
+        <label for="use_existing_card_yes">
+          <%= t('spree.use_existing_cc') %>
+        </label>
+        <br/>
+        <%= radio_button_tag 'use_existing_card', 'no' %>
+        <label for="use_existing_card_no">
+          <%= t('spree.use_new_cc_or_payment_method') %>
+        </label>
+      </div>
+
+      <div id="existing_cards">
+        <div class="field" data-hook="existing_cards">
+          <table class="existing-credit-card-list">
+            <tbody>
+              <% @wallet_payment_sources.each do |wallet_payment_source| %>
+                <%=
+                  render(
+                    partial: "spree/checkout/existing_payment/#{wallet_payment_source.payment_source.payment_method.partial_name}",
+                    locals: {
+                      wallet_payment_source: wallet_payment_source,
+                      default: wallet_payment_source == @default_wallet_payment_source,
+                    }
+                  )
+                %>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    <% end %>
+
+    <div id="payment-method-fields" data-hook>
+      <% @order.available_payment_methods.each do |method| %>
+      <p>
+        <label>
+          <%= radio_button_tag "order[payments_attributes][][payment_method_id]", method.id, method == @order.available_payment_methods.first %>
+          <%= t(method.name, scope: 'spree.payment_methods', default: method.name) %>
+        </label>
+      </p>
+      <% end %>
+    </div>
+
+    <ul id="payment-methods" class="list-group list-group-flush" data-hook>
+      <% @order.available_payment_methods.each do |method| %>
+        <li id="payment_method_<%= method.id %>" class="list-group-item <%= 'last' if method == @order.available_payment_methods.last %>" data-hook>
+          <fieldset>
+            <%= render partial: "spree/checkout/payment/#{method.partial_name}", locals: { payment_method: method } %>
+          </fieldset>
+        </li>
+      <% end %>
+    </ul>
+    <br style="clear:both;" />
+  </div>
+</fieldset>
+
+<br class="space" />
+
+<div class="form-buttons" data-hook="buttons">
+  <%= submit_tag t('spree.save_and_continue'), class: 'continue btn btn-sm btn-dark my-4' %>
+  <script>Spree.disableSaveOnClick();</script>
+</div>

--- a/app/views/spree/checkout/edit.html.erb
+++ b/app/views/spree/checkout/edit.html.erb
@@ -1,0 +1,37 @@
+<div id="checkout" data-hook>
+  <%= render partial: 'spree/shared/error_messages', locals: { target: @order } %>
+
+  <div class="row my-5" data-hook="checkout_header">
+    <h1 class="columns three alpha" data-hook="checkout_title"><%= t('spree.checkout') %></h1>
+    <div class="columns thirteen omega" data-hook="checkout_progress"><%= checkout_progress %></div>
+  </div>
+
+  <div class="row" data-hook="checkout_content">
+
+      <div class="col-12 col-md-8">
+        <div class="columns <%= if @order.state != 'confirm' then 'alpha twelve' else 'alpha omega sixteen' end %>" data-hook="checkout_form_wrapper">
+          <%= form_for @order, url: update_checkout_path(@order.state), html: { id: "checkout_form_#{@order.state}" } do |form| %>
+            <% if @order.state == 'address' || !@order.email? %>
+              <div class="field field-required form-floating" style='clear: both'>
+                <%= form.email_field :email, required: true, class: 'form-control' %>
+                <%= form.label :email %><br />
+              </div>
+            <% end %>
+            <%= render @order.state, form: form %>
+          <% end %>
+        </div>
+      </div>
+      <div class="col-12 col-md-4">
+        <% if @order.state != 'confirm' %>
+          <div id="checkout-summary" data-hook="checkout_summary_box" class="columns omega four">
+            <%= render partial: 'summary', locals: { order: @order } %>
+          </div>
+        <% end %>
+      </div>
+  </div>
+</div>
+
+<script>
+Spree.current_order_id = "<%= @order.number %>"
+Spree.current_order_token = "<%= @order.guest_token %>"
+</script>

--- a/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/app/views/spree/checkout/payment/_gateway.html.erb
@@ -1,0 +1,42 @@
+<%= image_tag 'credit_cards/credit_card.gif', id: 'credit-card-image' %>
+<% param_prefix = "payment_source[#{payment_method.id}]" %>
+
+<div class="field field-required card_name form-floating mb-3" data-hook="card_name">
+  <%= text_field_tag "#{param_prefix}[name]", @order.billing_name, { id: "name_on_card_#{payment_method.id}", autocomplete: "cc-name", class: 'cardName form-control' } %>
+  <%= label_tag "name_on_card_#{payment_method.id}", t('spree.name_on_card') %>
+</div>
+
+<div class="field field-required card_number form-floating mb-3" data-hook="card_number">
+  <%= text_field_tag "#{param_prefix}[number]", '', {id: 'card_number', class: 'required cardNumber form-control', size: 19, maxlength: 19, autocomplete: "cc-number", type: "tel" } %>
+  <%= label_tag "card_number", t('spree.card_number') %>
+
+  <span id="card_type" style="display:none;">
+    ( <span id="looks_like" ><%= t('spree.card_type_is') %> <span id="type"></span></span>
+      <span id="unrecognized"><%= t('spree.unrecognized_card_type') %></span>
+    )
+  </span>
+</div>
+
+<div class="row">
+    <div class="col-12 col-md-6">
+        <div class="field field-required card_expiration form-floating mb-3" data-hook="card_expiration">
+            <%= text_field_tag "#{param_prefix}[expiry]", '', id: 'card_expiry', class: "required cardExpiry form-control", type: "tel" %>
+            <%= label_tag "card_expiry", t('spree.expiration') %>
+        </div>
+    </div>
+    <div class="col-12 col-md-6">
+        <div class="field field-required card_code form-floating mb-3" data-hook="card_code">
+            <%= text_field_tag "#{param_prefix}[verification_value]", '', {id: 'card_code', class: 'required cardCode form-control', size: 5, type: "tel", autocomplete: "off" } %>
+            <%= label_tag "card_code", t('spree.card_code') %>
+            <%= link_to "(#{t('spree.what_is_this')})", spree.cvv_path, target: '_blank', "data-hook" => "cvv_link", id: "cvv_link" %>
+        </div>
+    </div>
+</div>
+
+<% if @order.bill_address %>
+  <%= fields_for "#{param_prefix}[address_attributes]", @order.bill_address do |f| %>
+    <%= render partial: 'spree/address/form_hidden', locals: { form: f } %>
+  <% end %>
+<% end %>
+
+<%= hidden_field_tag "#{param_prefix}[cc_type]", '', id: "cc_type", class: 'ccType' %>

--- a/app/views/spree/shared/_order_details.html.erb
+++ b/app/views/spree/shared/_order_details.html.erb
@@ -1,0 +1,146 @@
+<div class="row steps-data">
+
+  <% if order.has_checkout_step?("address") %>
+
+    <div class="col-12 col-md-4" data-hook="order-bill-address">
+      <h6 class="lead fw-bold"><%= t('spree.billing_address') %> <%= link_to "(#{t('spree.actions.edit')})", checkout_state_path(:address) unless order.completed? %></h6>
+      <%= render partial: 'spree/shared/address', locals: { address: order.bill_address } %>
+    </div>
+
+    <% if order.has_checkout_step?("delivery") %>
+      <div class="col-12 col-md-4" data-hook="order-ship-address">
+        <h6 class="lead fw-bold"><%= t('spree.shipping_address') %> <%= link_to "(#{t('spree.actions.edit')})", checkout_state_path(:address) unless order.completed? %></h6>
+        <%= render partial: 'spree/shared/address', locals: { address: order.ship_address } %>
+      </div>
+
+      <div class="col-12 col-md-4" data-hook="order-shipment">
+        <h6 class="lead fw-bold"><%= t('spree.shipments') %> <%= link_to "(#{t('spree.actions.edit')})", checkout_state_path(:delivery) unless order.completed? %></h6>
+        <div class="delivery">
+          <% order.shipments.each do |shipment| %>
+            <div>
+              <i class='fa fa-truck'></i>
+              <%= t('spree.shipment_details', stock_location: shipment.stock_location.name, shipping_method: shipment.selected_shipping_rate.name) %>
+            </div>
+          <% end %>
+        </div>
+        <%= render(partial: 'spree/shared/shipment_tracking', locals: {order: order}) if order.shipped? %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <% if order.has_checkout_step?("payment") %>
+    <div class="columns omega four">
+      <h6><%= t('spree.payment_information') %> <%= link_to "(#{t('spree.actions.edit')})", checkout_state_path(:payment) unless order.completed? %></h6>
+      <div class="payment-info">
+        <% order.payments.valid.each do |payment| %>
+          <%= render payment %><br/>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<hr />
+
+<table id='line-items' class="index columns alpha omega sixteen" data-hook="order_details">
+  <col width="15%" valign="middle" halign="center">
+  <col width="70%" valign="middle">
+  <col width="5%" valign="middle" halign="center">
+  <col width="5%" valign="middle" halign="center">
+  <col width="5%" valign="middle" halign="center">
+
+  <thead data-hook>
+    <tr data-hook="order_details_line_items_headers">
+      <th colspan="2"><%= t('spree.item') %></th>
+      <th class="price"><%= t('spree.price') %></th>
+      <th class="qty"><%= t('spree.qty') %></th>
+      <th class="total"><span><%= t('spree.total') %></span></th>
+    </tr>
+  </thead>
+
+  <tbody data-hook>
+    <% order.line_items.each do |item| %>
+      <tr data-hook="order_details_line_item_row">
+        <td data-hook="order_item_image">
+          <%= link_to(render('spree/shared/image',
+                             image: (item.variant.gallery.images.first || item.variant.product.gallery.images.first),
+                             size: :small), item.variant.product) %>
+        </td>
+        <td data-hook="order_item_description">
+          <h4><%= item.variant.product.name %></h4>
+          <%= truncated_product_description(item.variant.product) %>
+          <%= "(" + item.variant.options_text + ")" unless item.variant.option_values.empty? %>
+        </td>
+        <td data-hook="order_item_price" class="price"><span><%= item.single_money.to_html %></span></td>
+        <td data-hook="order_item_qty"><%= item.quantity %></td>
+        <td data-hook="order_item_total" class="total"><span><%= item.display_amount.to_html %></span></td>
+      </tr>
+    <% end %>
+  </tbody>
+  <tfoot id="order-total" data-hook="order_details_total">
+    <tr class="total">
+      <td colspan="4"><b><%= t('spree.order_total') %>:</b></td>
+      <td class="total"><span id="order_total"><%= order.display_order_total_after_store_credit.to_html %></span></td>
+    </tr>
+  </tfoot>
+
+  <tfoot id="subtotal" data-hook="order_details_subtotal">
+    <tr class="total" id="subtotal-row">
+      <td colspan="4"><b><%= t('spree.subtotal') %>:</b></td>
+      <td class="total"><span><%= order.display_item_total.to_html %></span></td>
+    </tr>
+  </tfoot>
+
+  <% if order.line_item_adjustments.exists? %>
+    <% if order.line_item_adjustments.promotion.eligible.exists? %>
+      <tfoot id="price-adjustments" data-hook="order_details_price_adjustments">
+        <% order.line_item_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
+          <tr class="total">
+            <td colspan="4"><%= t('spree.promotion') %>: <strong><%= label %></strong></td>
+            <td class="total"><span><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency) %></span></td>
+          </tr>
+        <% end %>
+      </tfoot>
+    <% end %>
+  <% end %>
+
+  <tfoot id='shipment-total'>
+    <% order.shipments.group_by { |s| s.selected_shipping_rate.name }.each do |name, shipments| %>
+      <tr class="total" data-hook='shipment-row'>
+        <td colspan="4"><%= t('spree.shipping') %>: <strong><%= name %></strong></td>
+        <td class="total"><span><%= Spree::Money.new(shipments.sum(&:total_before_tax), currency: order.currency).to_html %></span></td>
+      </tr>
+    <% end %>
+  </tfoot>
+
+  <% if order.all_adjustments.tax.exists? %>
+    <tfoot id="tax-adjustments" data-hook="order_details_tax_adjustments">
+      <% order.all_adjustments.tax.group_by(&:label).each do |label, adjustments| %>
+        <tr class="total">
+          <td colspan="4"><%= t('spree.tax') %>: <strong><%= label %></strong></td>
+          <td class="total"><span><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency) %></span></td>
+        </tr>
+      <% end %>
+    </tfoot>
+  <% end %>
+
+  <% if order.total_applicable_store_credit > 0.0 %>
+    <tfoot id="store-credit" data-hook="order_details_store_credit">
+      <tr class="total">
+        <td colspan='4'><%= t('spree.store_credit.store_credit') %>:</td>
+        <td class='total'><span><%= order.display_total_applicable_store_credit.to_html %></span></td>
+      </tr>
+    </tfoot>
+  <% end %>
+
+  <tfoot id="order-charges" data-hook="order_details_adjustments">
+    <% order.adjustments.eligible.each do |adjustment| %>
+    <% next if (adjustment.source_type == 'Spree::TaxRate') and (adjustment.amount == 0) %>
+      <tr class="total">
+        <td colspan="4"><strong><%= adjustment.label %></strong></td>
+        <td class="total"><span><%= adjustment.display_amount.to_html %></span></td>
+      </tr>
+    <% end %>
+  </tfoot>
+
+</table>


### PR DESCRIPTION
Quick Info
---
Add styles and improve UX from the checkout process

Migrations? :-1:

What does this change?
----
- Improve address view
- Improve delivery view
- Improve payment view

How do you manually test this?
----
Execute rails server then browse to the solidus main page, and follow the checkout process

Screenshots
----

### Desktop
![Screenshot 2022-07-26 at 13-49-46 Sample Store](https://user-images.githubusercontent.com/44456304/181088926-463ee169-d0b1-48ec-af88-f243b1d29100.png)
![Screenshot 2022-07-26 at 13-49-37 Sample Store](https://user-images.githubusercontent.com/44456304/181088929-1a14f730-a0b2-4566-b711-3f584241ef15.png)
![Screenshot 2022-07-26 at 13-49-27 Sample Store](https://user-images.githubusercontent.com/44456304/181088932-bbce48f7-d001-48cd-8ee0-ede1a800d09c.png)

